### PR TITLE
add requests as a dep cause oops fetch.py uses it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,6 @@ requires-python = ">=3.12"
 dependencies = [
     "discord-py>=2.4.0",
     "docker>=7.1.0",
+    "requests>=2.32.3",
     "strip-ansi>=0.1.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "discord-py" },
     { name = "docker" },
+    { name = "requests" },
     { name = "strip-ansi" },
 ]
 
@@ -166,6 +167,7 @@ dependencies = [
 requires-dist = [
     { name = "discord-py", specifier = ">=2.4.0" },
     { name = "docker", specifier = ">=7.1.0" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "strip-ansi", specifier = ">=0.1.1" },
 ]
 


### PR DESCRIPTION
fetch.py has only been working so far because docker also has a dep on requests, better to lock in that we want the dep regardless of whether docker has it or not