### PR TITLE
Fix fetch working only the first time after restarting the bot

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -7,8 +7,11 @@ from datetime import datetime, timedelta, timezone
 from os.path import isfile, join
 
 year = "2024"
-keys = filter(
-    None, [os.getenv("AOC_TOKEN_1"), os.getenv("AOC_TOKEN_2"), os.getenv("AOC_TOKEN_3")]
+keys = list(
+    filter(
+        None,
+        [os.getenv("AOC_TOKEN_1"), os.getenv("AOC_TOKEN_2"), os.getenv("AOC_TOKEN_3")],
+    )
 )
 
 base_input_dir: Final = "."


### PR DESCRIPTION
`filter` being an iterator means it becomes exhausted after the first iteration, and this prevents any further iteration over the `keys` to get more inputs until the bot is restarted and the iterator is recreated. Wrapping it in a list should fix the issue as it allows it to be iterated multiple times.