### PR TITLE
Move input dir to aoc_inputs and store yearwise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /23/
 /24/
 /25/
+/aoc_inputs
 /runner/.Dockerfile.swp
 /runner/target
 /solutions/target/

--- a/fetch.py
+++ b/fetch.py
@@ -14,12 +14,10 @@ keys = list(
     )
 )
 
-base_input_dir: Final = "."
+base_input_dir: Final = "aoc_inputs"
 
 def get_year_input_dir(year: int | str) -> str:
-    # FIXME(ultrabear): at some point the structure can be changed to be multiyear, add stubs for it now
-    _ = year
-    return base_input_dir
+    return f"{base_input_dir}/{year}"
 
 
 def get_day_input_dir(year: int | str, day: int) -> str:


### PR DESCRIPTION
moves the inputs cache to its own subfolder and indexes by year